### PR TITLE
Fixed bug with negative number of empty stars

### DIFF
--- a/client/src/Components/Star.jsx
+++ b/client/src/Components/Star.jsx
@@ -37,13 +37,17 @@ const Stars = (props) => {
   const { score } = props;
   const rounded = roundToNearestQuarter(score);
   const [base, percent] = String(rounded).split('.');
-  const extraEmptyStars = 5 - Number(base) - 1;
-  const stars = [...Array(Number(base))].map(() => <Star percent="100" />);
-  const emptyStars = [...Array(extraEmptyStars)].map(() => <Star percent="00" />);
+  const numEmptyStars = percent !== '00' ? 5 - Number(base) - 1
+    : 5 - Number(base);
+  const filledStars = [...Array(Number(base))].map(() => <Star percent="100" />);
+  const emptyStars = numEmptyStars > 0
+    ? [...Array(numEmptyStars)].map(() => <Star percent="00" />)
+    : '';
+  const fractionalStar = percent !== '00' ? <Star percent={percent} /> : '';
   return (
     <div className="stars">
-      {stars}
-      <Star percent={percent} />
+      {filledStars}
+      {fractionalStar}
       {emptyStars}
     </div>
   );


### PR DESCRIPTION
The star ratings are rendered by calculating the number of filled stars and the number of empty stars.  The empty stars were calculated by subtracting the filled stars AND and extra 1 for a fractional star.  This led to a bug where 5 star ratings attempt to construct an array of length -1.  I added extra conditional logic to check if there is any fraction before calculating the empty stars